### PR TITLE
fix bug where only the first test file is evaluated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # vertigo-rs
 
 ## Introduction
-This repo is currently a WIP. It is a fork of Joran Honig's [vertigo](https://github.com/JoranHonig/vertigo) with support for foundry added.
+This is an actively maintained fork of Joran Honig's [vertigo](https://github.com/JoranHonig/vertigo) with support for foundry added.
 
-It strongly depends on contracts being in `src` and having the same file in `test`. Added flexibility is a work in progress.
+This tool will mutate files in `src/` and run `forge test` to see if the mutant survives. Files that end with `.t.sol` or have `test` in their name (including the path) are ignored. Files in lib (or any directory that isn't src/) will not be mutated.
 
-A python package will be created after this build is stabilized. For now, you can test it by cloning it and running it in the foundry project you are doing mutation testing on. Command line options are the same as the original repo. You do not need to specify if you are in a foundry project, the presence of a `foundry.toml` file will signify to this tool that you are in a foundry repo. If you have configuration files for truffle or hardhat in your project, this tool might not work. You can temporarily change their names.
+You do not need to specify that you are in a foundry project, the presence of a `foundry.toml` file will signify to this tool that you are in a foundry repo. If you have configuration files for truffle or hardhat in your project, this tool will get confused. You can temporarily change their names.
 
 ```bash
 git clone https://github.com/RareSkills/vertigo-rs

--- a/eth_vertigo/cli/main.py
+++ b/eth_vertigo/cli/main.py
@@ -130,6 +130,7 @@ def run(
             click.echo("[-] Vertigo needs at least one network to run analyses on")
             return
 
+        click.echo("[+] If this is taking a while, vertigo-rs is probably installing dependencies in your project")
         try:
             if project_type == "truffle":
                 campaign = TruffleCampaign(
@@ -159,7 +160,8 @@ def run(
                     suggesters=test_suggesters,
                 )
 
-        except:
+        except e:
+            # print(e) uncomment for debugging
             click.echo("[-] Encountered an error while setting up the core campaign")
             if isinstance(network_pool, DynamicNetworkPool):
                 networks = network_pool.claimed_networks.keys()

--- a/eth_vertigo/core/campaign.py
+++ b/eth_vertigo/core/campaign.py
@@ -113,7 +113,6 @@ class BaseCampaign(ABC, Campaign):
             suggesters=None
     ):
         super().__init__(filters=filters, suggesters=suggesters)
-
         self.project_directory = project_directory
         self.source_directory = project_directory / "build" / "contracts"
 

--- a/eth_vertigo/interfaces/common/tester.py
+++ b/eth_vertigo/interfaces/common/tester.py
@@ -21,7 +21,7 @@ from typing import List, Dict, Union
 
 def normalize_mocha(mocha_json: dict) -> Dict[str, TestResult]:
  
-    file_name = list(mocha_json.keys())[0]
+    file_names = list(mocha_json.keys())
     tests = {}
     # it really is mocha
     if "tests" in mocha_json:
@@ -33,15 +33,16 @@ def normalize_mocha(mocha_json: dict) -> Dict[str, TestResult]:
 
     # it is foundry
     else:
-        for test_name in mocha_json[file_name]["test_results"].keys():
-            # foundry does not provide this information
-            # title: testIncrement(), test_name
-            # fullTitle: testIncrement(), test_name
-            # duration: 0
-            if mocha_json[file_name]["test_results"][test_name]["success"] == True:
-                tests[test_name] = TestResult(test_name, test_name, 0, True)
-            else:
-                tests[test_name] = TestResult(test_name, test_name, 0, False)
+        for file_name in file_names:
+            for test_name in mocha_json[file_name]["test_results"].keys():
+                # foundry does not provide this information
+                # title: testIncrement(), test_name
+                # fullTitle: testIncrement(), test_name
+                # duration: 0
+                if mocha_json[file_name]["test_results"][test_name]["success"] == True:
+                    tests[test_name] = TestResult(test_name, test_name, 0, True)
+                else:
+                    tests[test_name] = TestResult(test_name, test_name, 0, False)
         return tests
 
 

--- a/eth_vertigo/interfaces/foundry/__init__.py
+++ b/eth_vertigo/interfaces/foundry/__init__.py
@@ -25,7 +25,6 @@ class FoundryCampaign(BaseCampaign):
         compiler = FoundryCompiler(foundry_command)
         tester = FoundryTester(foundry_command, str(project_directory), compiler)
         source_file_builder = lambda ast, full_path: FoundrySourceFile(ast, full_path)
-
         super().__init__(
             project_directory=project_directory,
             mutators=mutators,
@@ -48,8 +47,9 @@ class FoundryCampaign(BaseCampaign):
         # TODO: This might not be the most reliable way to find the source files
         #       but it works for now. Glob the source directory, then find the set intersection
         #       between the files in src and the files in the out directory
-        src_file_names = set(map(os.path.basename, glob.glob('src/**/*.sol', recursive=True)))
-
+        full_names = glob.glob('src/**/*.sol', recursive=True) 
+        full_names = set(filter(lambda name: not '.t.sol' in name and 'test' not in name, full_names))
+        src_file_names = set(map(os.path.basename, full_names))
         contract_directories = []
         def explore_contracts(directory: Path):
             for item in directory.iterdir():

--- a/eth_vertigo/interfaces/foundry/compile.py
+++ b/eth_vertigo/interfaces/foundry/compile.py
@@ -59,7 +59,7 @@ class FoundryCompiler(Compiler, FoundryCore):
         def explore_contracts(directory: Path):
             src_files = [f.name for f in (w_dir / "src").iterdir() if f.is_file()]
             for item in directory.iterdir():
-                if item.name in src_files and item.name.endswith(".sol"):
+                if item.name in src_files and item.name.endswith(".sol") and not item.name.endswith(".t.sol") and not "test" in item.name:
                     contract_directories.append(item)
                 elif item.is_dir():
                     explore_contracts(item)


### PR DESCRIPTION
This is more flexible if the tests are put inside the src directory. This version ignores files with `.t.sol` extensions or `test` in the absolute path name.