### PR TITLE
Checking and fixing rights while deleting the temporary directory on Windows 

### DIFF
--- a/eth_vertigo/interfaces/common/tester.py
+++ b/eth_vertigo/interfaces/common/tester.py
@@ -60,15 +60,16 @@ def clean_build_directory(project_path: str, build_directory: str = "build"):
         shutil.rmtree(build_dir)
 
 
-def rm_temp_directory(temp_dir: str):
-    shutil.rmtree(temp_dir, onerror = redo_with_write)
-
-def redo_with_write(redo_func, path, err):
+def redo_with_write(redo_func, path, _):
     if not os.access(path, os.W_OK):
         os.chmod(path, stat.S_IWRITE)
         redo_func(path)
     else:
         raise
+
+
+def rm_temp_directory(temp_dir: str):
+    shutil.rmtree(temp_dir, onexc = redo_with_write)
 
 
 def apply_mutation(mutation: Mutation, working_directory):

--- a/eth_vertigo/interfaces/common/tester.py
+++ b/eth_vertigo/interfaces/common/tester.py
@@ -60,16 +60,15 @@ def clean_build_directory(project_path: str, build_directory: str = "build"):
         shutil.rmtree(build_dir)
 
 
-def redo_with_write(redo_func, path, _):
+def rm_temp_directory(temp_dir: str):
+    shutil.rmtree(temp_dir, onerror = redo_with_write)
+
+def redo_with_write(redo_func, path, err):
     if not os.access(path, os.W_OK):
         os.chmod(path, stat.S_IWRITE)
         redo_func(path)
     else:
         raise
-
-
-def rm_temp_directory(temp_dir: str):
-    shutil.rmtree(temp_dir, onexc = redo_with_write)
 
 
 def apply_mutation(mutation: Mutation, working_directory):

--- a/eth_vertigo/interfaces/common/tester.py
+++ b/eth_vertigo/interfaces/common/tester.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from tempfile import mkdtemp
 from distutils.dir_util import copy_tree
 import shutil
+import os
+import stat
 
 from eth_vertigo.core import Mutation
 from eth_vertigo.test_runner.file_editor import FileEditor
@@ -59,7 +61,14 @@ def clean_build_directory(project_path: str, build_directory: str = "build"):
 
 
 def rm_temp_directory(temp_dir: str):
-    shutil.rmtree(temp_dir)
+    shutil.rmtree(temp_dir, onerror = redo_with_write)
+
+def redo_with_write(redo_func, path, err):
+    if not os.access(path, os.W_OK):
+        os.chmod(path, stat.S_IWRITE)
+        redo_func(path)
+    else:
+        raise
 
 
 def apply_mutation(mutation: Mutation, working_directory):


### PR DESCRIPTION
Added an `onerror `function that is called if the rm.tree has an error. The function checks whether it is an access error then fixes the rights.

`onerror` will be deprecated and should be replaced by `onexc` starting python version 3.12, see the [what's new documentation](https://docs.python.org/zh-cn/dev/whatsnew/3.12.html#shutil)