### PR TITLE
fix: do not consider custom errors as void calls

### DIFF
--- a/eth_vertigo/interfaces/foundry/mutator.py
+++ b/eth_vertigo/interfaces/foundry/mutator.py
@@ -91,7 +91,7 @@ class FoundrySourceFile(SourceFile):
                 continue
             if "function" not in function_typedef:
                 continue
-            if function_identifier["typeDescriptions"]["typeIdentifier"].startswith("t_function_event"):
+            if function_identifier["typeDescriptions"]["typeIdentifier"].startswith(("t_function_event", "t_function_error_pure")):
                 continue
 
             try:

--- a/eth_vertigo/interfaces/hardhat/mutator.py
+++ b/eth_vertigo/interfaces/hardhat/mutator.py
@@ -91,7 +91,7 @@ class HardhatSourceFile(SourceFile):
                 continue
             if "function" not in function_typedef:
                 continue
-            if function_identifier["typeDescriptions"]["typeIdentifier"].startswith("t_function_event"):
+            if function_identifier["typeDescriptions"]["typeIdentifier"].startswith(("t_function_event", "t_function_error_pure")):
                 continue
 
             try:

--- a/eth_vertigo/interfaces/truffle/mutator.py
+++ b/eth_vertigo/interfaces/truffle/mutator.py
@@ -97,7 +97,7 @@ class SolidityFile(SourceFile):
                 continue
             if "function" not in function_typedef:
                 continue
-            if function_identifier["typeDescriptions"]["typeIdentifier"].startswith("t_function_event"):
+            if function_identifier["typeDescriptions"]["typeIdentifier"].startswith(("t_function_event", "t_function_error_pure")):
                 continue
 
             try:


### PR DESCRIPTION
Custom errors were considered as void calls leading to compilation errors hence a non reliable mutation score. This PR discard those mutations.
<img width="1139" alt="custom-error" src="https://github.com/RareSkills/vertigo-rs/assets/92337658/3955adb2-2fb9-4e23-af98-8f56424793f2">

This was tested only with foundry. 
As truffle and hardhat seems to use the same `get_void_calls` function, it was also modified there.
